### PR TITLE
Fixed a problem that NaN is mixed in when calculating RimLight in MToon from Santarh/MToon#117

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2018 Masataka SUMI
 Copyright (c) 2022 宵夜
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/VRMShaders/VRM/MToon/MToon/Resources/Shaders/MToonFrontBackCore.cginc
+++ b/VRMShaders/VRM/MToon/MToon/Resources/Shaders/MToonFrontBackCore.cginc
@@ -234,7 +234,7 @@ float4 frag_forward(v2f i) : SV_TARGET
     half3 mixedRimLighting = lighting + indirectLighting;
 #endif
     half3 rimLighting = lerp(staticRimLighting, mixedRimLighting, _RimLightingMix);
-    half3 rim = pow(saturate(1.0 - dot(worldNormal, worldView) + _RimLift), _RimFresnelPower) * _RimColor.rgb * tex2D(_RimTexture, mainUv).rgb;
+    half3 rim = pow(saturate(1.0 - dot(worldNormal, worldView) + _RimLift), max(_RimFresnelPower, EPS_COL)) * _RimColor.rgb * tex2D(_RimTexture, mainUv).rgb;
     col += lerp(rim * rimLighting, half3(0, 0, 0), i.isOutline);
 
     // additive matcap
@@ -433,7 +433,7 @@ float4 back_frag_forward(v2f i) : SV_TARGET
     half3 mixedRimLighting = lighting + indirectLighting;
 #endif
     half3 rimLighting = lerp(staticRimLighting, mixedRimLighting, _RimLightingMix);
-    half3 rim = pow(saturate(1.0 - dot(worldNormal, worldView) + _RimLift), _RimFresnelPower) * _RimColor.rgb * tex2D(_RimTexture, mainUv).rgb;
+    half3 rim = pow(saturate(1.0 - dot(worldNormal, worldView) + _RimLift), max(_RimFresnelPower, EPS_COL)) * _RimColor.rgb * tex2D(_RimTexture, mainUv).rgb;
     col += lerp(rim * rimLighting, half3(0, 0, 0), i.isOutline);
 
     // additive matcap


### PR DESCRIPTION
and complement missing license.